### PR TITLE
Fix multiple definition for abs

### DIFF
--- a/include/cleaner_system.hpp
+++ b/include/cleaner_system.hpp
@@ -237,7 +237,7 @@ private:
     unsigned long last_read_time = 0;
 };
 
-Cleaner::State abs(Cleaner::State state)
+inline Cleaner::State abs(Cleaner::State state)
 {
     state.jaw_rotation = std::abs(state.jaw_rotation);
     state.jaw_pos      = std::abs(state.jaw_pos);


### PR DESCRIPTION
## Summary
- prevent duplicate symbol errors by inlining `abs(Cleaner::State)`

## Testing
- `clang-format -i include/cleaner_system.hpp`

------
https://chatgpt.com/codex/tasks/task_e_6848a94888d48330b9ddc2a08b4fac67